### PR TITLE
Fix CSRF token encoding to use URL-safe base64 and add test for unsafe characters

### DIFF
--- a/csrf/csrf.go
+++ b/csrf/csrf.go
@@ -5,7 +5,6 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -128,9 +127,6 @@ func generateRandomBytes(n int) ([]byte, error) {
 		return nil, err
 	}
 
-	// hexEncoded := make([]byte, hex.EncodedLen(len(b)))
-	// hex.Encode(hexEncoded, b)
-	log.Println(string(b), len(b))
 	return b, nil
 }
 
@@ -209,7 +205,6 @@ func mask(realToken []byte, r *http.Request) string {
 func unmask(issued []byte) []byte {
 	// Issued tokens are always masked and combined with the pad.
 	if len(issued) != tokenLength*2 {
-		log.Println("CSRF: issued token is not the expected length", len(issued), tokenLength*2)
 		return nil
 	}
 

--- a/csrf/csrf_test.go
+++ b/csrf/csrf_test.go
@@ -3,6 +3,7 @@ package csrf_test
 import (
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gobuffalo/middleware/csrf"
@@ -45,6 +46,17 @@ func Test_CSRFOnIdempotentAction(t *testing.T) {
 	w := httptest.New(ctCSRFApp())
 	res := w.HTML("/csrf").Get()
 	r.Equal(200, res.Code)
+}
+
+func Test_ContainsNoUnsafeBase64Chars(t *testing.T) {
+	r := require.New(t)
+
+	w := httptest.New(ctCSRFApp())
+	res := w.HTML("/csrf").Get()
+	token := res.Body.String()
+	l := strings.ContainsAny(token, "/+=")
+
+	r.Equal(false, l)
 }
 
 func Test_CSRFOnJSONRequest(t *testing.T) {

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -35,7 +35,8 @@ func app() *buffalo.App {
 	// Setup URL prefix Language extractor
 	t.LanguageExtractors = append(t.LanguageExtractors, i18n.URLPrefixLanguageExtractor)
 
-	app.Use(t.Middleware())
+	mwT := t.Middleware()
+	app.Use(mwT)
 	app.GET("/", func(c buffalo.Context) error {
 		return c.Render(200, r.HTML("index.html"))
 	})
@@ -74,7 +75,7 @@ func app() *buffalo.App {
 	noI18n := func(c buffalo.Context) error {
 		return c.Render(200, r.HTML("localized_view.html"))
 	}
-	app.Middleware.Skip(t.Middleware(), noI18n)
+	app.Middleware.Skip(mwT, noI18n)
 	app.GET("/localized-disabled", noI18n)
 	app.GET("/{lang:fr|en}/index", func(c buffalo.Context) error {
 		return c.Render(200, r.HTML("index.html"))


### PR DESCRIPTION
This PR updates the CSRF token masking logic to use base64.RawURLEncoding instead of the default base64.StdEncoding, ensuring that the generated token does not contain unsafe characters such as /, +, or =.
